### PR TITLE
Initial template for publishing terraform files

### DIFF
--- a/jobs/publish_terraform_artifact.yml
+++ b/jobs/publish_terraform_artifact.yml
@@ -1,4 +1,9 @@
 ﻿parameters:
+  - name: ArtifactName
+    type: string
+    default: 'TerraformArtifact'
+    displayName: 'Artifact Name for Target Path to be saved as.'
+
   - name: RelativePathToTerraformFiles
     type: string
     displayName: "Target Path to Terraform files (.tf,.tfvars) that require publishing as artifact."
@@ -14,4 +19,4 @@ jobs:
       - template: ../tasks/publish_pipeline_artifact.yml
         parameters:
           TargetPath: ${{ variables.terraformTargetPath }}
-          ArtifactName: "TerraformArtifact"
+          ArtifactName: ${{ parameters.ArtifactName }}

--- a/jobs/publish_terraform_artifact.yml
+++ b/jobs/publish_terraform_artifact.yml
@@ -1,0 +1,17 @@
+﻿parameters:
+  - name: RelativePathToTerraformFiles
+    type: string
+    displayName: "Target Path to Terraform files (.tf,.tfvars) that require publishing as artifact."
+
+jobs:
+  - job: PublishTerraformArtifact
+    variables:
+      terraformTargetPath: $(Build.SourcesDirectory)/${{ parameters.RelativePathToTerraformFiles }}
+    workspace:
+      clean: all
+    displayName: "Publish Terraform Artifact"
+    steps:
+      - template: ../tasks/publish_pipeline_artifact.yml
+        parameters:
+          TargetPath: ${{ variables.terraformTargetPath }}
+          ArtifactName: "TerraformArtifact"

--- a/pipelines/infrastructure_pipeline.yml
+++ b/pipelines/infrastructure_pipeline.yml
@@ -8,7 +8,9 @@
     type: string
     displayName: "Target Path to Terraform files (.tf,.tfvars) that require publishing as artifact."
 
-pool: ${{ variables.PipelinePool }}
+variables:
+  - name: PipelinePool
+    value: ${{ parameters.PipelinePool }}
 
 stages:
   - template: ../stages/terraform_build.yml

--- a/pipelines/infrastructure_pipeline.yml
+++ b/pipelines/infrastructure_pipeline.yml
@@ -1,7 +1,14 @@
 ﻿parameters:
+  - name: PipelinePool
+    type: string
+    default: "Mare Nectaris"
+    displayName: "The pool that the pipeline will run from the highest level."
+
   - name: RelativePathToTerraformFiles
     type: string
     displayName: "Target Path to Terraform files (.tf,.tfvars) that require publishing as artifact."
+
+pool: ${{ variables.PipelinePool }}
 
 stages:
   - template: ../stages/terraform_build.yml

--- a/pipelines/infrastructure_pipeline.yml
+++ b/pipelines/infrastructure_pipeline.yml
@@ -1,0 +1,9 @@
+﻿parameters:
+  - name: RelativePathToTerraformFiles
+    type: string
+    displayName: "Target Path to Terraform files (.tf,.tfvars) that require publishing as artifact."
+
+stages:
+  - template: ../stages/terraform_build.yml
+    parameters:
+      RelativePathToTerraformFiles: ${{ parameters.RelativePathToTerraformFiles }}

--- a/stages/terraform_build.yml
+++ b/stages/terraform_build.yml
@@ -1,4 +1,9 @@
 ﻿parameters:
+  - name: ArtifactName
+    type: string
+    default: 'TerraformArtifact'
+    displayName: 'Artifact Name for Target Path to be saved as.'
+
   - name: RelativePathToTerraformFiles
     type: string
     displayName: "Target Path to Terraform files (.tf,.tfvars) that require publishing as artifact."
@@ -9,4 +14,5 @@ stages:
     jobs:
       - template: ../jobs/publish_terraform_artifact.yml
         parameters:
+          ArtifactName: ${{ parameters.ArtifactName }}
           RelativePathToTerraformFiles: ${{ parameters.RelativePathToTerraformFiles }}

--- a/stages/terraform_build.yml
+++ b/stages/terraform_build.yml
@@ -1,0 +1,12 @@
+﻿parameters:
+  - name: RelativePathToTerraformFiles
+    type: string
+    displayName: "Target Path to Terraform files (.tf,.tfvars) that require publishing as artifact."
+
+stages:
+  - stage: Build
+    displayName: "Build"
+    jobs:
+      template: ../jobs/publish_terraform_artifact.yml
+      parameters:
+        RelativePathToTerraformFiles: ${{ parameters.RelativePathToTerraformFiles }}

--- a/stages/terraform_build.yml
+++ b/stages/terraform_build.yml
@@ -7,6 +7,6 @@ stages:
   - stage: Build
     displayName: "Build"
     jobs:
-      template: ../jobs/publish_terraform_artifact.yml
-      parameters:
-        RelativePathToTerraformFiles: ${{ parameters.RelativePathToTerraformFiles }}
+      - template: ../jobs/publish_terraform_artifact.yml
+        parameters:
+          RelativePathToTerraformFiles: ${{ parameters.RelativePathToTerraformFiles }}

--- a/tasks/publish_pipeline_artifact.yml
+++ b/tasks/publish_pipeline_artifact.yml
@@ -1,0 +1,16 @@
+﻿parameters:
+  - name: targetPath
+    type: string
+    default: '$(Pipeline.Workspace)'
+    displayName: 'Target Path to publish as artifact.'
+  - name: artifactName
+    type: string
+    default: 'drop'
+    displayName: 'Artifact Name for Target Path to be saved as.'
+
+steps:
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish Pipeline Artifact ${{ parameters.artifactName }} '
+    inputs:
+      targetPath: ${{ parameters.targetPath }}
+      artifact: ${{ parameters.artifactName }}

--- a/tasks/publish_pipeline_artifact.yml
+++ b/tasks/publish_pipeline_artifact.yml
@@ -1,16 +1,17 @@
 ﻿parameters:
+  - name: ArtifactName
+    type: string
+    default: 'Drop'
+    displayName: 'Artifact Name for Target Path to be saved as.'
+
   - name: TargetPath
     type: string
     default: '$(Pipeline.Workspace)'
     displayName: 'Target Path to publish as artifact.'
-  - name: ArtifactName
-    type: string
-    default: 'drop'
-    displayName: 'Artifact Name for Target Path to be saved as.'
 
 steps:
   - task: PublishPipelineArtifact@1
     displayName: "Publish Pipeline Artifact '${{ parameters.ArtifactName }}'"
     inputs:
-      targetPath: ${{ parameters.TargetPath }}
       artifact: ${{ parameters.ArtifactName }}
+      targetPath: ${{ parameters.TargetPath }}

--- a/tasks/publish_pipeline_artifact.yml
+++ b/tasks/publish_pipeline_artifact.yml
@@ -1,16 +1,16 @@
 ﻿parameters:
-  - name: targetPath
+  - name: TargetPath
     type: string
     default: '$(Pipeline.Workspace)'
     displayName: 'Target Path to publish as artifact.'
-  - name: artifactName
+  - name: ArtifactName
     type: string
     default: 'drop'
     displayName: 'Artifact Name for Target Path to be saved as.'
 
 steps:
   - task: PublishPipelineArtifact@1
-    displayName: 'Publish Pipeline Artifact ${{ parameters.artifactName }} '
+    displayName: "Publish Pipeline Artifact '${{ parameters.ArtifactName }}'"
     inputs:
-      targetPath: ${{ parameters.targetPath }}
-      artifact: ${{ parameters.artifactName }}
+      targetPath: ${{ parameters.TargetPath }}
+      artifact: ${{ parameters.ArtifactName }}

--- a/tests/pipelines/infrastructure_pipeline/terraform/main.tf
+++ b/tests/pipelines/infrastructure_pipeline/terraform/main.tf
@@ -1,0 +1,19 @@
+﻿terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+provider "random" {}
+
+resource "random_integer" "example" {
+  min = 1
+  max = 100
+}
+
+output "random_number" {
+  value = random_integer.example.result
+}

--- a/tests/pipelines/infrastructure_pipeline/test.yml
+++ b/tests/pipelines/infrastructure_pipeline/test.yml
@@ -9,7 +9,7 @@ resources:
 variables:
   PipelinePoolTest: Mare Nectaris
 
-pool: ${{ variables.PipelinePoolTest }} # Variable defined within template, overridable via template parameter 'PipelinePool'.
+pool: ${{ PipelinePoolTest }} # Variable defined within template, overridable via template parameter 'PipelinePool'.
 
 extends:
   template: pipelines/infrastructure_pipeline.yml@PipelineTemplates

--- a/tests/pipelines/infrastructure_pipeline/test.yml
+++ b/tests/pipelines/infrastructure_pipeline/test.yml
@@ -6,6 +6,8 @@ resources:
       name: UKHO/devops-azdo-yaml-pipeline-templates
       ref: refs/heads/initial-template-for-deploying-terraform
 
+pool: ${{ variables.PipelinePool }} # Variable defined within template, overridable via template parameter 'PipelinePool'.
+
 extends:
   template: pipelines/infrastructure_pipeline.yml@PipelineTemplates
   parameters:

--- a/tests/pipelines/infrastructure_pipeline/test.yml
+++ b/tests/pipelines/infrastructure_pipeline/test.yml
@@ -6,10 +6,7 @@ resources:
       name: UKHO/devops-azdo-yaml-pipeline-templates
       ref: refs/heads/initial-template-for-deploying-terraform
 
-variables:
-  PipelinePoolTest: Mare Nectaris
-
-pool: $(PipelinePoolTest) # Variable defined within template, overridable via template parameter 'PipelinePool'.
+pool: $(PipelinePool) # Variable defined within template, overridable via template parameter 'PipelinePool'.
 
 extends:
   template: pipelines/infrastructure_pipeline.yml@PipelineTemplates

--- a/tests/pipelines/infrastructure_pipeline/test.yml
+++ b/tests/pipelines/infrastructure_pipeline/test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: PipelineTemplates
       type: github

--- a/tests/pipelines/infrastructure_pipeline/test.yml
+++ b/tests/pipelines/infrastructure_pipeline/test.yml
@@ -6,7 +6,10 @@ resources:
       name: UKHO/devops-azdo-yaml-pipeline-templates
       ref: refs/heads/initial-template-for-deploying-terraform
 
-pool: ${{ variables.PipelinePool }} # Variable defined within template, overridable via template parameter 'PipelinePool'.
+variables:
+  PipelinePoolTest: Mare Nectaris
+
+pool: ${{ variables.PipelinePoolTest }} # Variable defined within template, overridable via template parameter 'PipelinePool'.
 
 extends:
   template: pipelines/infrastructure_pipeline.yml@PipelineTemplates

--- a/tests/pipelines/infrastructure_pipeline/test.yml
+++ b/tests/pipelines/infrastructure_pipeline/test.yml
@@ -1,0 +1,11 @@
+﻿resources:
+  repositories:
+    - repository: PipelineTemplates
+      type: github
+      endpoint: UKHO
+      name: UKHO/devops-azdo-yaml-pipeline-templates
+
+extends:
+  template: pipelines/infrastructure_pipeline.yml@PipelineTemplates
+  parameters:
+    RelativePathToTerraformFiles: tests/pipelines/infrastructure_pipeline/terraform

--- a/tests/pipelines/infrastructure_pipeline/test.yml
+++ b/tests/pipelines/infrastructure_pipeline/test.yml
@@ -4,6 +4,7 @@ resources:
       type: github
       endpoint: UKHO
       name: UKHO/devops-azdo-yaml-pipeline-templates
+      ref: refs/heads/initial-template-for-deploying-terraform
 
 extends:
   template: pipelines/infrastructure_pipeline.yml@PipelineTemplates

--- a/tests/pipelines/infrastructure_pipeline/test.yml
+++ b/tests/pipelines/infrastructure_pipeline/test.yml
@@ -9,7 +9,7 @@ resources:
 variables:
   PipelinePoolTest: Mare Nectaris
 
-pool: ${{ PipelinePoolTest }} # Variable defined within template, overridable via template parameter 'PipelinePool'.
+pool: $(PipelinePoolTest) # Variable defined within template, overridable via template parameter 'PipelinePool'.
 
 extends:
   template: pipelines/infrastructure_pipeline.yml@PipelineTemplates


### PR DESCRIPTION
This pull request introduces a reusable Azure DevOps pipeline template system for publishing Terraform artifacts. The changes modularize the pipeline into parameterized YAML templates for jobs, stages, and tasks, making it easier to manage and reuse pipeline logic for Terraform deployments. A sample test pipeline and Terraform configuration are also included to demonstrate usage.