### PR TITLE
Disable _test.yml pipelines triggering on draft PRs

### DIFF
--- a/tests/jobs/manual_verification/double_resume_test.yml
+++ b/tests/jobs/manual_verification/double_resume_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -12,7 +12,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/manual_verification.yml@AzDOPipelineTemplates

--- a/tests/jobs/manual_verification/double_resume_test.yml
+++ b/tests/jobs/manual_verification/double_resume_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/manual_verification/resume_test.yml
+++ b/tests/jobs/manual_verification/resume_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -12,7 +12,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/manual_verification.yml@AzDOPipelineTemplates

--- a/tests/jobs/manual_verification/resume_test.yml
+++ b/tests/jobs/manual_verification/resume_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_build/additional_files_test.yml
+++ b/tests/jobs/terraform_build/additional_files_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_build/additional_files_test.yml
+++ b/tests/jobs/terraform_build/additional_files_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -12,7 +12,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_build/build_test.yml
+++ b/tests/jobs/terraform_build/build_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_build/build_test.yml
+++ b/tests/jobs/terraform_build/build_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -12,7 +12,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_build/double_build_test.yml
+++ b/tests/jobs/terraform_build/double_build_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_build/double_build_test.yml
+++ b/tests/jobs/terraform_build/double_build_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -20,7 +20,10 @@ variables:
     value: tests/shared_resources/basic_terraform
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_build/injection_steps_test.yml
+++ b/tests/jobs/terraform_build/injection_steps_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_build/injection_steps_test.yml
+++ b/tests/jobs/terraform_build/injection_steps_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -12,7 +12,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_deploy/apply_basic_test.yml
+++ b/tests/jobs/terraform_deploy/apply_basic_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_deploy/apply_basic_test.yml
+++ b/tests/jobs/terraform_deploy/apply_basic_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -12,7 +12,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_deploy/apply_with_key_vault_test.yml
+++ b/tests/jobs/terraform_deploy/apply_with_key_vault_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_deploy/apply_with_key_vault_test.yml
+++ b/tests/jobs/terraform_deploy/apply_with_key_vault_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -13,7 +13,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_deploy/apply_with_multiple_mappings_test.yml
+++ b/tests/jobs/terraform_deploy/apply_with_multiple_mappings_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_deploy/apply_with_multiple_mappings_test.yml
+++ b/tests/jobs/terraform_deploy/apply_with_multiple_mappings_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -12,7 +12,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_deploy/apply_with_outputs_future_stage_test.yml
+++ b/tests/jobs/terraform_deploy/apply_with_outputs_future_stage_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_deploy/apply_with_outputs_future_stage_test.yml
+++ b/tests/jobs/terraform_deploy/apply_with_outputs_future_stage_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -12,7 +12,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 stages:
   - stage: RunTemplate

--- a/tests/jobs/terraform_deploy/apply_with_outputs_same_stage_test.yml
+++ b/tests/jobs/terraform_deploy/apply_with_outputs_same_stage_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_deploy/apply_with_outputs_same_stage_test.yml
+++ b/tests/jobs/terraform_deploy/apply_with_outputs_same_stage_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -12,7 +12,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_deploy/double_apply_basic_test.yml
+++ b/tests/jobs/terraform_deploy/double_apply_basic_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_deploy/double_apply_basic_test.yml
+++ b/tests/jobs/terraform_deploy/double_apply_basic_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -16,7 +16,10 @@ variables:
     value: tests/shared_resources/basic_terraform
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_deploy/double_plan_basic_test.yml
+++ b/tests/jobs/terraform_deploy/double_plan_basic_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_deploy/double_plan_basic_test.yml
+++ b/tests/jobs/terraform_deploy/double_plan_basic_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -16,7 +16,10 @@ variables:
     value: tests/shared_resources/basic_terraform
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_deploy/plan_apply_basic_test.yml
+++ b/tests/jobs/terraform_deploy/plan_apply_basic_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_deploy/plan_apply_basic_test.yml
+++ b/tests/jobs/terraform_deploy/plan_apply_basic_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -12,7 +12,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_deploy/plan_basic_test.yml
+++ b/tests/jobs/terraform_deploy/plan_basic_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_deploy/plan_basic_test.yml
+++ b/tests/jobs/terraform_deploy/plan_basic_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -12,7 +12,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_deploy/plan_with_multiple_mappings_test.yml
+++ b/tests/jobs/terraform_deploy/plan_with_multiple_mappings_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_deploy/plan_with_multiple_mappings_test.yml
+++ b/tests/jobs/terraform_deploy/plan_with_multiple_mappings_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -12,7 +12,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_deploy/plan_with_verify_mode_test.yml
+++ b/tests/jobs/terraform_deploy/plan_with_verify_mode_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_deploy/plan_with_verify_mode_test.yml
+++ b/tests/jobs/terraform_deploy/plan_with_verify_mode_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -12,7 +12,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_gated_deployment/apply_only_test.yml
+++ b/tests/jobs/terraform_gated_deployment/apply_only_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_gated_deployment/apply_only_test.yml
+++ b/tests/jobs/terraform_gated_deployment/apply_only_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -16,7 +16,10 @@ variables:
     value: terraform_build
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_gated_deployment/double_apply_only_test.yml
+++ b/tests/jobs/terraform_gated_deployment/double_apply_only_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_gated_deployment/double_apply_only_test.yml
+++ b/tests/jobs/terraform_gated_deployment/double_apply_only_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -20,7 +20,10 @@ variables:
     value: tests/shared_resources/basic_terraform
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_gated_deployment/double_plan_only_test.yml
+++ b/tests/jobs/terraform_gated_deployment/double_plan_only_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_gated_deployment/double_plan_only_test.yml
+++ b/tests/jobs/terraform_gated_deployment/double_plan_only_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -21,7 +21,10 @@ variables:
     
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_gated_deployment/double_plan_verify_apply_test.yml
+++ b/tests/jobs/terraform_gated_deployment/double_plan_verify_apply_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_gated_deployment/double_plan_verify_apply_test.yml
+++ b/tests/jobs/terraform_gated_deployment/double_plan_verify_apply_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -20,7 +20,10 @@ variables:
     value: tests/shared_resources/basic_terraform
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_gated_deployment/plan_only_test.yml
+++ b/tests/jobs/terraform_gated_deployment/plan_only_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_gated_deployment/plan_only_test.yml
+++ b/tests/jobs/terraform_gated_deployment/plan_only_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -12,7 +12,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_gated_deployment/plan_verify_apply_test.yml
+++ b/tests/jobs/terraform_gated_deployment/plan_verify_apply_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_gated_deployment/plan_verify_apply_test.yml
+++ b/tests/jobs/terraform_gated_deployment/plan_verify_apply_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -16,7 +16,10 @@ variables:
     value: terraform_build
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/jobs/terraform_gated_deployment/plan_verify_apply_verify_disabled_test.yml
+++ b/tests/jobs/terraform_gated_deployment/plan_verify_apply_verify_disabled_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/jobs/terraform_gated_deployment/plan_verify_apply_verify_disabled_test.yml
+++ b/tests/jobs/terraform_gated_deployment/plan_verify_apply_verify_disabled_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -12,7 +12,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 jobs:
   - template: jobs/terraform_build.yml@AzDOPipelineTemplates

--- a/tests/pipelines/terraform_pipeline/elastic_test.yml
+++ b/tests/pipelines/terraform_pipeline/elastic_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/pipelines/terraform_pipeline/elastic_test.yml
+++ b/tests/pipelines/terraform_pipeline/elastic_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -13,7 +13,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 extends:
   template: pipelines/terraform_pipeline.yml@AzDOPipelineTemplates

--- a/tests/pipelines/terraform_pipeline/linux_test.yml
+++ b/tests/pipelines/terraform_pipeline/linux_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/pipelines/terraform_pipeline/linux_test.yml
+++ b/tests/pipelines/terraform_pipeline/linux_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -13,7 +13,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 extends:
   template: pipelines/terraform_pipeline.yml@AzDOPipelineTemplates

--- a/tests/pipelines/terraform_pipeline/windows_test.yml
+++ b/tests/pipelines/terraform_pipeline/windows_test.yml
@@ -1,4 +1,4 @@
-﻿resources:
+resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github

--- a/tests/pipelines/terraform_pipeline/windows_test.yml
+++ b/tests/pipelines/terraform_pipeline/windows_test.yml
@@ -1,4 +1,4 @@
-resources:
+﻿resources:
   repositories:
     - repository: AzDOPipelineTemplates
       type: github
@@ -13,7 +13,10 @@ pool:
 trigger: none
 
 pr:
-  - main
+  branches:
+    include:
+      - main
+  drafts: false
 
 extends:
   template: pipelines/terraform_pipeline.yml@AzDOPipelineTemplates


### PR DESCRIPTION
Prevent all of the `_test.yml` pipelines triggering when the PR to main is in draft state to reduce unnecessary load on the agent pools.